### PR TITLE
Update rosdep keys

### DIFF
--- a/rosdep/newkeys.yaml
+++ b/rosdep/newkeys.yaml
@@ -1,6 +1,8 @@
 libgl1-mesa-dev:
   ubuntu: [libgl1-mesa-dev]
+libglu1-mesa-dev:
+  ubuntu: [libglu1-mesa-dev]
 libglfw3-dev:
   ubuntu: [libglfw3-dev]
-libgtk-3-0-dev:
-  ubuntu: [libgtk-3-0-dev]
+libgtk-3-dev:
+  ubuntu: [libgtk-3-dev]


### PR DESCRIPTION
Adds the libglu1-mesa-dev package to the custom rosdep keys for this build and fixes the mistake in the libgtk-3-dev package name.

Once we've gotten the build passing, we'll contribute these keys to the upstream rosdep database in https://github.com/ros/rosdistro